### PR TITLE
ci: add docker image build to ci pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,3 +15,16 @@ jobs:
    - run: yarn
    - run: yarn test
    - run: node index.js
+   
+   - name: Set up QEMU
+     uses: docker/setup-qemu-action@v1
+
+   - name: Set up Docker Buildx
+     uses: docker/setup-buildx-action@v1
+
+   - name: Build and push
+     id: docker_build
+     uses: docker/build-push-action@v2
+     with:
+      push: false
+      tags: gpmarchi/fullcycle-primeiro-workflow-ci:latest


### PR DESCRIPTION
Enable ci pipeline to build the project's docker image