### PR TITLE
chore: add sonarqube output folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,7 @@ dist
 # SvelteKit build / generate output
 .svelte-kit
 
+# Sonarqube files
+.scannerwork
+
 # End of https://www.toptal.com/developers/gitignore/api/node


### PR DESCRIPTION
Ignore sonarqube output folder and files when committing to github